### PR TITLE
feat: clean up globals.css by removing unused imports and simplifying color variables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,29 +1,26 @@
-/* removed react-data-grid global import (no longer used) */
-
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
+  --background: #ffffff;
+  --foreground: #171717;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
+    --background: #0a0a0a;
+    --foreground: #ededed;
   }
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  background: var(--background);
+  color: var(--foreground);
+  font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
This pull request updates the global styles in `src/app/globals.css` to simplify and modernize the way colors and fonts are handled, as well as to remove unused imports. The changes primarily focus on improving theme management and cleaning up the CSS.

Theme and style improvements:

* Switched from Tailwind's directive-based import (`@tailwind base;`, etc.) to a single `@import "tailwindcss";` statement for better clarity and maintainability.
* Replaced the old RGB-based background and foreground variables with simpler hex color variables (`--background`, `--foreground`) and updated their values for both light and dark modes.
* Introduced a new `@theme inline` block to define theme-related CSS variables (like `--color-background`, `--color-foreground`, and font variables) for more structured theming.
* Updated the `body` styles to use the new color variables and set a default sans-serif font, removing the previous gradient background.

Code cleanup:

* Removed an unused global import for `react-data-grid` to keep the CSS file clean.