### PR TITLE
[T4] Dependabot の更新PRをグループ化する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,20 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
- - package-ecosystem: "npm"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "develop"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` の npm エコシステムに `groups` を追加し、`production` / `development` の dependency-type でPRをグループ化
- `target-branch: "develop"` を npm・devcontainers 両方に追加
- npm に `day: "monday"` を追加してスケジュールを明示
- インデントを2スペースに統一

## Test plan

- [ ] `.github/dependabot.yml` の YAML 構文が正しいこと
- [ ] Dependabot が次回実行時に production / development の2グループでPRを作成することを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)