### PR TITLE
fix: TypeScript 6 の CSS side-effect import エラーを修正

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -8,6 +8,11 @@
   "files": {
     "ignoreUnknown": true,
     "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
   },
   "formatter": {
     "enabled": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "allowArbitraryExtensions": true,
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

PR #18 の dev dependencies アップデート（TypeScript 6・Biome 2.4.12）によるビルド・lint 失敗を修正。

### tsconfig.json
- `allowArbitraryExtensions: true` を追加
- TypeScript 6 から CSS ファイルの side-effect import（`import "./globals.css"`）に型宣言が必要になったことへの対応

### biome.json
- `$schema` を `2.2.0` → `2.4.12` に更新
- `css.parser.tailwindDirectives: true` を追加
  - Biome 2.4.12 から Tailwind の `@theme inline` 構文をパースするために必要

## Test plan

- [ ] `npm run lint` が成功すること
- [ ] `npm run build:static` が成功すること
- [ ] GitHub Actions の CI・deploy ワークフローが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)