### PR TITLE
fix: T6/T7 パスワード二重ハッシング削除・SQLエスケープ統一

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,23 +54,19 @@ export default function Home() {
     await new Promise((res) => setTimeout(res, 0));
 
     try {
-      const teachersUsers = teacherRows
-        .filter((r) => r.userId && r.userId.trim().length > 0)
-        .map((r) => ({
-          userId: r.userId,
-          pwHash: hashPassword(r.password || "password"),
-          role: 1,
-        }));
+      const mergedRows = [
+        ...teacherRows.filter((r) => r.userId && r.userId.trim().length > 0),
+        ...studentRows.filter((r) => r.userId && r.userId.trim().length > 0),
+      ].map((r) => ({
+        ...r,
+        password: hashPassword(r.password || "password"),
+      }));
 
-      const studentsUsers = studentRows
-        .filter((r) => r.userId && r.userId.trim().length > 0)
-        .map((r) => ({
-          userId: r.userId,
-          pwHash: hashPassword(r.password || "password"),
-          role: 2,
-        }));
-
-      const allUsers = [...teachersUsers, ...studentsUsers];
+      const allUsers = mergedRows.map((r) => ({
+        userId: r.userId,
+        pwHash: r.password,
+        role: r.role === "teacher" ? 1 : 2,
+      }));
 
       const usersSql = generateUsersSql({
         organizationName,
@@ -79,14 +75,6 @@ export default function Home() {
         users: allUsers,
       });
       setGeneratedSQL(usersSql || "-- No users found");
-
-      const mergedRows = [
-        ...teacherRows.filter((r) => r.userId && r.userId.trim().length > 0),
-        ...studentRows.filter((r) => r.userId && r.userId.trim().length > 0),
-      ].map((r) => ({
-        ...r,
-        password: hashPassword(r.password || "password"),
-      }));
 
       const membersSql = generateMembersSql({
         organizationName,

--- a/src/lib/sql/generateMembersSql.test.ts
+++ b/src/lib/sql/generateMembersSql.test.ts
@@ -103,4 +103,13 @@ describe("generateMembersSql()", () => {
     expect(result).toContain("@first_member_id + 0");
     expect(result).toContain("@first_member_id + 1");
   });
+
+  it("userId のシングルクォートがエスケープされる", () => {
+    const result = generateMembersSql({
+      ...baseOpts,
+      rows: [{ ...row, userId: "o'brien" }],
+    });
+    expect(result).toContain("'o''brien'");
+    expect(result).toContain("o''brien@example.com");
+  });
 });

--- a/src/lib/sql/generateMembersSql.ts
+++ b/src/lib/sql/generateMembersSql.ts
@@ -27,7 +27,7 @@ export function generateMembersSql(opts: MemberOptions) {
   const periodVals: string[] = [];
 
   rows.forEach((r, idx) => {
-    const loginId = r.userId.replace(/'/g, "''");
+    const loginId = r.userId;
     const memberName = r.userName?.trim() ?? "";
     const pwHash = r.password ? r.password : ""; // caller should provide hashed pw if desired
     const mail = `${loginId}@${md}`;

--- a/src/lib/sql/generateMembersSql.ts
+++ b/src/lib/sql/generateMembersSql.ts
@@ -33,7 +33,7 @@ export function generateMembersSql(opts: MemberOptions) {
     const mail = `${loginId}@${md}`;
 
     memberVals.push(
-      `(${q(loginId)}, '0', '0', ${q(memberName)}, ${q(organizationName)}, '${zip}', ${pref}, ${q(cityName)}, ${q(address)}, ${q(phone)}, ${q(mail)}, NOW(), '${pwHash}', ${pref}, ${city}, NULL, '0', ${q(expiration)}, '0', NOW(), NOW(), NULL, '0')`,
+      `(${q(loginId)}, '0', '0', ${q(memberName)}, ${q(organizationName)}, '${zip}', ${pref}, ${q(cityName)}, ${q(address)}, ${q(phone)}, ${q(mail)}, NOW(), ${q(pwHash)}, ${pref}, ${city}, NULL, '0', ${q(expiration)}, '0', NOW(), NOW(), NULL, '0')`,
     );
 
     const base = `(@first_member_id + ${idx})`;

--- a/src/lib/sql/generateUsersSql.ts
+++ b/src/lib/sql/generateUsersSql.ts
@@ -8,7 +8,6 @@ export function generateUsersSql(opts: {
   users: UserRow[];
 }) {
   const { organizationName, pref, city, users } = opts;
-  const orgNameEsc = organizationName.replace(/'/g, "''");
 
   let sql = "";
 
@@ -23,7 +22,7 @@ export function generateUsersSql(opts: {
   updated_by,
   delete_flag
 ) VALUES
-  ('${orgNameEsc}', ${pref}, ${city}, 1, NOW(), 'admin', NOW(), 'admin', 0);\n\n`;
+  (${q(organizationName)}, ${pref}, ${city}, 1, NOW(), 'admin', NOW(), 'admin', 0);\n\n`;
 
   if (users.length > 0) {
     sql += "SET @user_group_id = LAST_INSERT_ID();\n\n";


### PR DESCRIPTION
## Summary

- **T6** `page.tsx` でパスワードが2回ハッシュされていた問題を修正。`mergedRows` 生成時の1箇所でハッシュ化し、`allUsers` はその結果を再利用する形に変更
- **T7** `generateUsersSql` の `orgNameEsc`（手書き `replace`）と `generateMembersSql` の `loginId` エスケープを `q()` ヘルパーに統一。`userId` シングルクォートエスケープのテストを追加

## Test plan

- [x] `npm test` 25テストすべてパス
- [x] `tsc --noEmit` 型エラーなし

Closes #21
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)