### PR TITLE
feat: [T8] role の型定義を ROLE_MAP / RoleLabel に統一する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import type { AccountData } from "@/components/AccountSpreadsheet";
 import AccountSpreadsheet from "@/components/AccountSpreadsheet";
 import { generateMembersSql } from "@/lib/sql/generateMembersSql";
 import { generateUsersSql } from "@/lib/sql/generateUsersSql";
 import { ROLE_MAP } from "@/lib/sql/types";
+import type { AccountData } from "@/lib/sql/types";
 
 // bcryptjs is used synchronously here (existing behavior). For large workloads consider
 // moving hashing into a Web Worker or to the server.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import type { AccountData } from "@/components/AccountSpreadsheet";
 import AccountSpreadsheet from "@/components/AccountSpreadsheet";
 import { generateMembersSql } from "@/lib/sql/generateMembersSql";
 import { generateUsersSql } from "@/lib/sql/generateUsersSql";
+import { ROLE_MAP } from "@/lib/sql/types";
 
 // bcryptjs is used synchronously here (existing behavior). For large workloads consider
 // moving hashing into a Web Worker or to the server.
@@ -65,7 +66,7 @@ export default function Home() {
       const allUsers = mergedRows.map((r) => ({
         userId: r.userId,
         pwHash: r.password,
-        role: r.role === "teacher" ? 1 : 2,
+        role: ROLE_MAP[r.role],
       }));
 
       const usersSql = generateUsersSql({

--- a/src/components/AccountSpreadsheet.tsx
+++ b/src/components/AccountSpreadsheet.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import type { RoleLabel } from "@/lib/sql/types";
 
 export interface AccountData {
   id: string;
   userId: string;
   userName: string;
   password: string;
-  role: string;
+  role: RoleLabel;
 }
 
 const COL_KEYS: (keyof AccountData)[] = ["userId", "userName", "password"];

--- a/src/components/AccountSpreadsheet.tsx
+++ b/src/components/AccountSpreadsheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import type { AccountData } from "@/lib/sql/types";
+import type { AccountData, RoleLabel } from "@/lib/sql/types";
 export type { AccountData } from "@/lib/sql/types";
 
 const COL_KEYS: (keyof AccountData)[] = ["userId", "userName", "password"];
@@ -37,7 +37,7 @@ const Row = memo(function RowComponent({
 }: {
   row: AccountData;
   rowIdx: number;
-  accountRole: "teacher" | "student";
+  accountRole: RoleLabel;
   onChangeField: (
     id: string,
     key: keyof AccountData,
@@ -59,7 +59,7 @@ const Row = memo(function RowComponent({
     rowIdx: number;
     columnKey: string;
   } | null>;
-  focusedRoleRef: React.MutableRefObject<"teacher" | "student" | null>;
+  focusedRoleRef: React.MutableRefObject<RoleLabel | null>;
 }) {
   // Row render (debug logging removed)
   return (
@@ -159,7 +159,7 @@ const Row = memo(function RowComponent({
 // RoleGrid moved to module scope and memoized so its identity is stable and
 // we can observe when it re-renders or is recreated.
 const RoleGridComponent = memo(function RoleGridComponent(props: {
-  accountRole: "teacher" | "student";
+  accountRole: RoleLabel;
   rows: AccountData[];
   setRows: React.Dispatch<React.SetStateAction<AccountData[]>>;
   teacherCounter: React.MutableRefObject<number>;
@@ -178,7 +178,7 @@ const RoleGridComponent = memo(function RoleGridComponent(props: {
     rowIdx: number;
     columnKey: string;
   } | null>;
-  focusedRoleRef: React.MutableRefObject<"teacher" | "student" | null>;
+  focusedRoleRef: React.MutableRefObject<RoleLabel | null>;
 }) {
   const {
     accountRole,
@@ -349,7 +349,7 @@ export default function AccountSpreadsheet(props: {
     rowIdx: number;
     columnKey: string;
   } | null>(null);
-  const focusedRoleRef = useRef<"teacher" | "student" | null>(null);
+  const focusedRoleRef = useRef<RoleLabel | null>(null);
 
   // handle paste from Excel/Sheets (TSV) at grid level
   useEffect(() => {

--- a/src/components/AccountSpreadsheet.tsx
+++ b/src/components/AccountSpreadsheet.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import type { RoleLabel } from "@/lib/sql/types";
-
-export interface AccountData {
-  id: string;
-  userId: string;
-  userName: string;
-  password: string;
-  role: RoleLabel;
-}
+import type { AccountData } from "@/lib/sql/types";
+export type { AccountData } from "@/lib/sql/types";
 
 const COL_KEYS: (keyof AccountData)[] = ["userId", "userName", "password"];
 

--- a/src/lib/sql/generateMembersSql.test.ts
+++ b/src/lib/sql/generateMembersSql.test.ts
@@ -18,7 +18,7 @@ const row = {
   userId: "teacher01",
   userName: "山田太郎",
   password: "$2b$10$hashedpassword",
-  role: "teacher",
+  role: "teacher" as const,
 };
 
 describe("generateMembersSql()", () => {

--- a/src/lib/sql/generateMembersSql.test.ts
+++ b/src/lib/sql/generateMembersSql.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { defaultMailDomain } from "./helpers";
 import { generateMembersSql } from "./generateMembersSql";
-import type { MemberOptions } from "./types";
+import type { AccountData, MemberOptions } from "./types";
 
 const baseOpts: MemberOptions = {
   organizationName: "テスト学校",
@@ -13,12 +13,12 @@ const baseOpts: MemberOptions = {
   mailDomain: "example.com",
 };
 
-const row = {
+const row: AccountData = {
   id: "t-1",
   userId: "teacher01",
   userName: "山田太郎",
   password: "$2b$10$hashedpassword",
-  role: "teacher" as const,
+  role: "teacher",
 };
 
 describe("generateMembersSql()", () => {

--- a/src/lib/sql/types.ts
+++ b/src/lib/sql/types.ts
@@ -1,7 +1,13 @@
-import type { AccountData } from "@/components/AccountSpreadsheet";
-
 export const ROLE_MAP = { teacher: 1, student: 2 } as const;
 export type RoleLabel = keyof typeof ROLE_MAP;
+
+export interface AccountData {
+  id: string;
+  userId: string;
+  userName: string;
+  password: string;
+  role: RoleLabel;
+}
 
 export type UserRow = {
   userId: string;

--- a/src/lib/sql/types.ts
+++ b/src/lib/sql/types.ts
@@ -1,5 +1,8 @@
 import type { AccountData } from "@/components/AccountSpreadsheet";
 
+export const ROLE_MAP = { teacher: 1, student: 2 } as const;
+export type RoleLabel = keyof typeof ROLE_MAP;
+
 export type UserRow = {
   userId: string;
   pwHash: string;


### PR DESCRIPTION
## Summary

- `src/lib/sql/types.ts` に `ROLE_MAP = { teacher: 1, student: 2 } as const` と `RoleLabel` 型を定義
- `AccountData.role` の型を `string` → `RoleLabel` に変更
- `page.tsx` の `r.role === "teacher" ? 1 : 2` を `ROLE_MAP[r.role]` に置き換え
- テストの `role: "teacher"` に `as const` を追加して型を揃える

## Test plan

- [x] `tsc --noEmit` 型エラーなし
- [x] `npm test` 25テストすべてパス

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)