### PR TITLE
feat: [T9] トランザクションラップを wrapInTransaction() に共通化する

### DIFF
--- a/src/lib/sql/generateMembersSql.test.ts
+++ b/src/lib/sql/generateMembersSql.test.ts
@@ -30,7 +30,7 @@ describe("generateMembersSql()", () => {
   it("START TRANSACTION と COMMIT でラップされる", () => {
     const result = generateMembersSql({ ...baseOpts, rows: [row] });
     expect(result).toMatch(/^START TRANSACTION;/);
-    expect(result).toMatch(/COMMIT;$/);
+    expect(result).toMatch(/COMMIT;\n$/);
   });
 
   it("member INSERT が含まれる", () => {

--- a/src/lib/sql/generateMembersSql.ts
+++ b/src/lib/sql/generateMembersSql.ts
@@ -5,6 +5,7 @@ import {
   defaultPhone,
   defaultZip,
   q,
+  wrapInTransaction,
 } from "./helpers";
 import type { MemberOptions } from "./types";
 
@@ -46,9 +47,7 @@ export function generateMembersSql(opts: MemberOptions) {
     );
   });
 
-  const memberSql = `START TRANSACTION;
-
-INSERT INTO member (
+  const memberSql = `INSERT INTO member (
   login_id,
   member_type,
   member_attribute,
@@ -94,10 +93,7 @@ INSERT INTO member_role_periods (
   create_date,
   update_date
 ) VALUES
-${periodVals.map((v) => `  ${v}`).join(",\n")};
+${periodVals.map((v) => `  ${v}`).join(",\n")};`;
 
-COMMIT;`;
-
-  // memberSql already contains START/COMMIT to match the original page.tsx output
-  return memberSql;
+  return wrapInTransaction(memberSql);
 }

--- a/src/lib/sql/generateUsersSql.ts
+++ b/src/lib/sql/generateUsersSql.ts
@@ -1,4 +1,4 @@
-import { q } from "./helpers";
+import { q, wrapInTransaction } from "./helpers";
 import type { UserRow } from "./types";
 
 export function generateUsersSql(opts: {
@@ -50,5 +50,5 @@ VALUES
     sql += ";";
   }
 
-  return `START TRANSACTION;\n\n${sql}\n\nCOMMIT;\n`;
+  return wrapInTransaction(sql);
 }

--- a/src/lib/sql/helpers.test.ts
+++ b/src/lib/sql/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { q } from "./helpers";
+import { q, wrapInTransaction } from "./helpers";
 
 describe("q()", () => {
   it("null を NULL に変換する", () => {
@@ -24,5 +24,18 @@ describe("q()", () => {
 
   it("空文字列をシングルクォートで囲む", () => {
     expect(q("")).toBe("''");
+  });
+});
+
+describe("wrapInTransaction()", () => {
+  it("START TRANSACTION と COMMIT でラップされる", () => {
+    const result = wrapInTransaction("SELECT 1;");
+    expect(result).toMatch(/^START TRANSACTION;\n/);
+    expect(result).toMatch(/\nCOMMIT;\n$/);
+  });
+
+  it("SQL 本文が間に含まれる", () => {
+    const result = wrapInTransaction("SELECT 1;");
+    expect(result).toContain("SELECT 1;");
   });
 });

--- a/src/lib/sql/helpers.ts
+++ b/src/lib/sql/helpers.ts
@@ -1,6 +1,9 @@
 export const q = (s: string | number | null) =>
   s === null ? "NULL" : `'${String(s).replace(/'/g, "''")}'`;
 
+export const wrapInTransaction = (sql: string): string =>
+  `START TRANSACTION;\n\n${sql}\n\nCOMMIT;\n`;
+
 export const defaultMailDomain = "kankouyohou.com";
 export const defaultZip = "105-0001";
 export const defaultCityName = "港区";


### PR DESCRIPTION
## Summary

- `helpers.ts` に `wrapInTransaction(sql)` を追加
- `generateUsersSql.ts` / `generateMembersSql.ts` のハードコードされた `START TRANSACTION` / `COMMIT` を `wrapInTransaction()` に置き換え
- `helpers.test.ts` に `wrapInTransaction()` のテストを追加（2件）
- `generateMembersSql.test.ts` の COMMIT 末尾マッチを `/COMMIT;\n$/` に修正（`wrapInTransaction` の末尾改行に合わせる）

## Test plan

- [x] `tsc --noEmit` 型エラーなし
- [x] `npm test` 27テストすべてパス

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)