### PR TITLE
feat: [T10] 行データ加工ロジックを toUserRows() に共通化する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
 import AccountSpreadsheet from "@/components/AccountSpreadsheet";
 import { generateMembersSql } from "@/lib/sql/generateMembersSql";
 import { generateUsersSql } from "@/lib/sql/generateUsersSql";
-import { ROLE_MAP } from "@/lib/sql/types";
+import { toUserRows } from "@/lib/sql/helpers";
 import type { AccountData } from "@/lib/sql/types";
 
 // bcryptjs is used synchronously here (existing behavior). For large workloads consider
@@ -63,11 +63,7 @@ export default function Home() {
         password: hashPassword(r.password || "password"),
       }));
 
-      const allUsers = mergedRows.map((r) => ({
-        userId: r.userId,
-        pwHash: r.password,
-        role: ROLE_MAP[r.role],
-      }));
+      const allUsers = toUserRows(mergedRows);
 
       const usersSql = generateUsersSql({
         organizationName,

--- a/src/lib/sql/helpers.test.ts
+++ b/src/lib/sql/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { q, wrapInTransaction } from "./helpers";
+import { q, toUserRows, wrapInTransaction } from "./helpers";
+import type { AccountData } from "./types";
 
 describe("q()", () => {
   it("null を NULL に変換する", () => {
@@ -37,5 +38,31 @@ describe("wrapInTransaction()", () => {
   it("SQL 本文が間に含まれる", () => {
     const result = wrapInTransaction("SELECT 1;");
     expect(result).toContain("SELECT 1;");
+  });
+});
+
+describe("toUserRows()", () => {
+  const base: AccountData = {
+    id: "t-1",
+    userId: "teacher01",
+    userName: "山田太郎",
+    password: "$2b$10$hashedpw",
+    role: "teacher",
+  };
+
+  it("teacher は role=1 に変換される", () => {
+    const result = toUserRows([base]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ userId: "teacher01", pwHash: "$2b$10$hashedpw", role: 1 });
+  });
+
+  it("student は role=2 に変換される", () => {
+    const result = toUserRows([{ ...base, id: "s-1", userId: "student01", role: "student" }]);
+    expect(result[0].role).toBe(2);
+  });
+
+  it("password フィールドを pwHash にマッピングする", () => {
+    const result = toUserRows([base]);
+    expect(result[0].pwHash).toBe("$2b$10$hashedpw");
   });
 });

--- a/src/lib/sql/helpers.test.ts
+++ b/src/lib/sql/helpers.test.ts
@@ -53,11 +53,17 @@ describe("toUserRows()", () => {
   it("teacher は role=1 に変換される", () => {
     const result = toUserRows([base]);
     expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({ userId: "teacher01", pwHash: "$2b$10$hashedpw", role: 1 });
+    expect(result[0]).toEqual({
+      userId: "teacher01",
+      pwHash: "$2b$10$hashedpw",
+      role: 1,
+    });
   });
 
   it("student は role=2 に変換される", () => {
-    const result = toUserRows([{ ...base, id: "s-1", userId: "student01", role: "student" }]);
+    const result = toUserRows([
+      { ...base, id: "s-1", userId: "student01", role: "student" },
+    ]);
     expect(result[0].role).toBe(2);
   });
 

--- a/src/lib/sql/helpers.ts
+++ b/src/lib/sql/helpers.ts
@@ -1,8 +1,19 @@
+import { ROLE_MAP } from "./types";
+import type { AccountData, UserRow } from "./types";
+
 export const q = (s: string | number | null) =>
   s === null ? "NULL" : `'${String(s).replace(/'/g, "''")}'`;
 
 export const wrapInTransaction = (sql: string): string =>
   `START TRANSACTION;\n\n${sql}\n\nCOMMIT;\n`;
+
+/** ハッシュ済みパスワードを持つ AccountData[] を UserRow[] に変換する */
+export const toUserRows = (rows: AccountData[]): UserRow[] =>
+  rows.map((r) => ({
+    userId: r.userId,
+    pwHash: r.password,
+    role: ROLE_MAP[r.role],
+  }));
 
 export const defaultMailDomain = "kankouyohou.com";
 export const defaultZip = "105-0001";


### PR DESCRIPTION
## Summary

- `helpers.ts` に `toUserRows(rows: AccountData[]): UserRow[]` を追加
  - ハッシュ済みパスワードを持つ `AccountData[]` を `UserRow[]` に変換
  - `ROLE_MAP` を使って role を number に変換
- `page.tsx` の `allUsers` 生成を `toUserRows(mergedRows)` に置き換え（`ROLE_MAP` の直接参照を削除）
- `helpers.test.ts` に `toUserRows()` のテストを追加（3件）

> **Note:** issue 原案の `hashPassword` 引数渡しパターンは T6 で解消済みの二重ハッシュを再導入するため不採用。ハッシュ済み rows を受け取る設計に変更。

## Test plan

- [x] `tsc --noEmit` 型エラーなし
- [x] `npm test` 30テストすべてパス

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)