### PR TITLE
feat: [T12] page.tsx のロジックをカスタムフックに分離する

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,9 @@ account-sql-generator/
 │   │   └── globals.css       # Tailwind インポート・グローバルスタイル
 │   ├── components/
 │   │   └── AccountSpreadsheet.tsx  # スプレッドシートエディタコンポーネント
+│   ├── hooks/
+│   │   ├── useSQLGeneration.ts          # SQL生成・データ加工ロジック
+│   │   └── useClipboardAndDownload.ts   # クリップボードコピー・ファイルダウンロード
 │   └── lib/
 │       └── sql/
 │           ├── types.ts             # TypeScript インターフェース定義

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,14 +2,9 @@
 
 import { useCallback, useState } from "react";
 import AccountSpreadsheet from "@/components/AccountSpreadsheet";
-import { generateMembersSql } from "@/lib/sql/generateMembersSql";
-import { generateUsersSql } from "@/lib/sql/generateUsersSql";
-import { toUserRows } from "@/lib/sql/helpers";
+import { useClipboardAndDownload } from "@/hooks/useClipboardAndDownload";
+import { useSQLGeneration } from "@/hooks/useSQLGeneration";
 import type { AccountData } from "@/lib/sql/types";
-
-// bcryptjs is used synchronously here (existing behavior). For large workloads consider
-// moving hashing into a Web Worker or to the server.
-const bcrypt = require("bcryptjs");
 
 export default function Home() {
   const [organizationName, setOrganizationName] = useState("");
@@ -19,12 +14,20 @@ export default function Home() {
   const [endDate, setEndDate] = useState("");
   const [teacherRows, setTeacherRows] = useState<AccountData[]>([]);
   const [studentRows, setStudentRows] = useState<AccountData[]>([]);
-  const [generatedSQL, setGeneratedSQL] = useState("");
-  const [generatedMemberSQL, setGeneratedMemberSQL] = useState("");
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [copiedUsers, setCopiedUsers] = useState(false);
-  const [copiedMembers, setCopiedMembers] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const { generatedSQL, generatedMemberSQL, isGenerating, errorMessage, generateSQL } =
+    useSQLGeneration({
+      organizationName,
+      prefCode,
+      municipalityCode,
+      startDate,
+      endDate,
+      teacherRows,
+      studentRows,
+    });
+
+  const { copiedUsers, copiedMembers, copyToClipboard, downloadSqlFile } =
+    useClipboardAndDownload(organizationName);
 
   const handleDataChange = useCallback(
     (teacher: AccountData[], student: AccountData[]) => {
@@ -33,116 +36,6 @@ export default function Home() {
     },
     [],
   );
-
-  const hashPassword = (pw: string) => {
-    const salt = bcrypt.genSaltSync(10);
-    return bcrypt.hashSync(pw, salt);
-  };
-
-  const generateSQL = async () => {
-    if (!organizationName) {
-      setGeneratedSQL("-- 組織名を入力してください");
-      setGeneratedMemberSQL("");
-      return;
-    }
-
-    const pref = parseInt(prefCode || "0", 10);
-    const city = parseInt(municipalityCode || "0", 10);
-
-    setIsGenerating(true);
-    setErrorMessage(null);
-    // Allow spinner to render before doing synchronous CPU work.
-    await new Promise((res) => setTimeout(res, 0));
-
-    try {
-      const mergedRows = [
-        ...teacherRows.filter((r) => r.userId && r.userId.trim().length > 0),
-        ...studentRows.filter((r) => r.userId && r.userId.trim().length > 0),
-      ].map((r) => ({
-        ...r,
-        password: hashPassword(r.password || "password"),
-      }));
-
-      const allUsers = toUserRows(mergedRows);
-
-      const usersSql = generateUsersSql({
-        organizationName,
-        pref,
-        city,
-        users: allUsers,
-      });
-      setGeneratedSQL(usersSql || "-- No users found");
-
-      const membersSql = generateMembersSql({
-        organizationName,
-        pref,
-        city,
-        rows: mergedRows,
-        startDate,
-        endDate,
-        mailDomain: "kankouyohou.com",
-      });
-      setGeneratedMemberSQL(membersSql || "-- No members found");
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error("generateSQL failed", err);
-      setErrorMessage(
-        "処理中にエラーが発生しました。詳細はコンソールを確認してください。",
-      );
-    } finally {
-      setIsGenerating(false);
-    }
-  };
-
-  const copyToClipboard = async (text: string, which: "users" | "members") => {
-    try {
-      await navigator.clipboard.writeText(text || "");
-      if (which === "users") {
-        setCopiedUsers(true);
-        setTimeout(() => setCopiedUsers(false), 2000);
-      } else {
-        setCopiedMembers(true);
-        setTimeout(() => setCopiedMembers(false), 2000);
-      }
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error("copy failed", err);
-    }
-  };
-
-  // download given text as a .sql file. filename uses organizationName fallback.
-  const downloadSqlFile = (text: string, which: "users" | "members") => {
-    try {
-      const blob = new Blob([text || ""], {
-        type: "application/sql;charset=utf-8",
-      });
-      const url = URL.createObjectURL(blob);
-      // Build filename base: remove half-width/全角 spaces and all symbols.
-      // Keep only Unicode letters and numbers so Japanese stays but spaces/symbols are removed.
-      const filenameBase =
-        organizationName && organizationName.trim().length > 0
-          ? (() => {
-              const cleaned = organizationName
-                .trim()
-                // remove everything except Unicode letters and numbers
-                .replace(/[^\p{L}\p{N}]/gu, "")
-                .slice(0, 100);
-              return cleaned.length > 0 ? cleaned : "sql_export";
-            })()
-          : "sql_export";
-      const filename = `${filenameBase}_${which}.sql`;
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error("download failed", err);
-    }
-  };
 
   return (
     <div className="min-h-screen bg-gray-50 p-6 relative">

--- a/src/hooks/useClipboardAndDownload.ts
+++ b/src/hooks/useClipboardAndDownload.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+export function useClipboardAndDownload(organizationName: string) {
+  const [copiedUsers, setCopiedUsers] = useState(false);
+  const [copiedMembers, setCopiedMembers] = useState(false);
+
+  const copyToClipboard = async (text: string, which: "users" | "members") => {
+    try {
+      await navigator.clipboard.writeText(text || "");
+      if (which === "users") {
+        setCopiedUsers(true);
+        setTimeout(() => setCopiedUsers(false), 2000);
+      } else {
+        setCopiedMembers(true);
+        setTimeout(() => setCopiedMembers(false), 2000);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("copy failed", err);
+    }
+  };
+
+  const downloadSqlFile = (text: string, which: "users" | "members") => {
+    try {
+      const blob = new Blob([text || ""], {
+        type: "application/sql;charset=utf-8",
+      });
+      const url = URL.createObjectURL(blob);
+      // Build filename base: remove half-width/全角 spaces and all symbols.
+      // Keep only Unicode letters and numbers so Japanese stays but spaces/symbols are removed.
+      const filenameBase =
+        organizationName && organizationName.trim().length > 0
+          ? (() => {
+              const cleaned = organizationName
+                .trim()
+                // remove everything except Unicode letters and numbers
+                .replace(/[^\p{L}\p{N}]/gu, "")
+                .slice(0, 100);
+              return cleaned.length > 0 ? cleaned : "sql_export";
+            })()
+          : "sql_export";
+      const filename = `${filenameBase}_${which}.sql`;
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("download failed", err);
+    }
+  };
+
+  return { copiedUsers, copiedMembers, copyToClipboard, downloadSqlFile };
+}

--- a/src/hooks/useClipboardAndDownload.ts
+++ b/src/hooks/useClipboardAndDownload.ts
@@ -1,20 +1,34 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export function useClipboardAndDownload(organizationName: string) {
   const [copiedUsers, setCopiedUsers] = useState(false);
   const [copiedMembers, setCopiedMembers] = useState(false);
+  const usersTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const membersTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (usersTimerRef.current) clearTimeout(usersTimerRef.current);
+      if (membersTimerRef.current) clearTimeout(membersTimerRef.current);
+    };
+  }, []);
 
   const copyToClipboard = async (text: string, which: "users" | "members") => {
     try {
       await navigator.clipboard.writeText(text || "");
       if (which === "users") {
+        if (usersTimerRef.current) clearTimeout(usersTimerRef.current);
         setCopiedUsers(true);
-        setTimeout(() => setCopiedUsers(false), 2000);
+        usersTimerRef.current = setTimeout(() => setCopiedUsers(false), 2000);
       } else {
+        if (membersTimerRef.current) clearTimeout(membersTimerRef.current);
         setCopiedMembers(true);
-        setTimeout(() => setCopiedMembers(false), 2000);
+        membersTimerRef.current = setTimeout(
+          () => setCopiedMembers(false),
+          2000,
+        );
       }
     } catch (err) {
       // eslint-disable-next-line no-console

--- a/src/hooks/useSQLGeneration.ts
+++ b/src/hooks/useSQLGeneration.ts
@@ -53,8 +53,8 @@ export function useSQLGeneration({
 
     try {
       const mergedRows = [
-        ...teacherRows.filter((r) => r.userId && r.userId.trim().length > 0),
-        ...studentRows.filter((r) => r.userId && r.userId.trim().length > 0),
+        ...teacherRows.filter((r) => r.userId.trim().length > 0),
+        ...studentRows.filter((r) => r.userId.trim().length > 0),
       ].map((r) => ({
         ...r,
         password: hashPassword(r.password || "password"),

--- a/src/hooks/useSQLGeneration.ts
+++ b/src/hooks/useSQLGeneration.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { generateMembersSql } from "@/lib/sql/generateMembersSql";
+import { generateUsersSql } from "@/lib/sql/generateUsersSql";
+import { toUserRows } from "@/lib/sql/helpers";
+import type { AccountData } from "@/lib/sql/types";
+
+// bcryptjs is used synchronously here (existing behavior). For large workloads consider
+// moving hashing into a Web Worker or to the server.
+const bcrypt = require("bcryptjs");
+
+const hashPassword = (pw: string): string => {
+  const salt = bcrypt.genSaltSync(10);
+  return bcrypt.hashSync(pw, salt);
+};
+
+type UseSQLGenerationProps = {
+  organizationName: string;
+  prefCode: string;
+  municipalityCode: string;
+  startDate: string;
+  endDate: string;
+  teacherRows: AccountData[];
+  studentRows: AccountData[];
+};
+
+export function useSQLGeneration({
+  organizationName,
+  prefCode,
+  municipalityCode,
+  startDate,
+  endDate,
+  teacherRows,
+  studentRows,
+}: UseSQLGenerationProps) {
+  const [generatedSQL, setGeneratedSQL] = useState("");
+  const [generatedMemberSQL, setGeneratedMemberSQL] = useState("");
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const generateSQL = async () => {
+    if (!organizationName) {
+      setGeneratedSQL("-- 組織名を入力してください");
+      setGeneratedMemberSQL("");
+      return;
+    }
+
+    const pref = parseInt(prefCode || "0", 10);
+    const city = parseInt(municipalityCode || "0", 10);
+
+    setIsGenerating(true);
+    setErrorMessage(null);
+    // Allow spinner to render before doing synchronous CPU work.
+    await new Promise((res) => setTimeout(res, 0));
+
+    try {
+      const mergedRows = [
+        ...teacherRows.filter((r) => r.userId && r.userId.trim().length > 0),
+        ...studentRows.filter((r) => r.userId && r.userId.trim().length > 0),
+      ].map((r) => ({
+        ...r,
+        password: hashPassword(r.password || "password"),
+      }));
+
+      const usersSql = generateUsersSql({
+        organizationName,
+        pref,
+        city,
+        users: toUserRows(mergedRows),
+      });
+      setGeneratedSQL(usersSql || "-- No users found");
+
+      const membersSql = generateMembersSql({
+        organizationName,
+        pref,
+        city,
+        rows: mergedRows,
+        startDate,
+        endDate,
+        mailDomain: "kankouyohou.com",
+      });
+      setGeneratedMemberSQL(membersSql || "-- No members found");
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("generateSQL failed", err);
+      setErrorMessage(
+        "処理中にエラーが発生しました。詳細はコンソールを確認してください。",
+      );
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return { generatedSQL, generatedMemberSQL, isGenerating, errorMessage, generateSQL };
+}

--- a/src/hooks/useSQLGeneration.ts
+++ b/src/hooks/useSQLGeneration.ts
@@ -4,11 +4,8 @@ import { useState } from "react";
 import { generateMembersSql } from "@/lib/sql/generateMembersSql";
 import { generateUsersSql } from "@/lib/sql/generateUsersSql";
 import { toUserRows } from "@/lib/sql/helpers";
+import bcrypt from "bcryptjs";
 import type { AccountData } from "@/lib/sql/types";
-
-// bcryptjs is used synchronously here (existing behavior). For large workloads consider
-// moving hashing into a Web Worker or to the server.
-const bcrypt = require("bcryptjs");
 
 const hashPassword = (pw: string): string => {
   const salt = bcrypt.genSaltSync(10);


### PR DESCRIPTION
## Summary

- `src/hooks/useSQLGeneration.ts` を新規作成
  - SQL生成・データ加工・bcrypt ハッシュ化・状態管理（`generatedSQL`, `generatedMemberSQL`, `isGenerating`, `errorMessage`）を集約
- `src/hooks/useClipboardAndDownload.ts` を新規作成
  - クリップボードコピー・ファイルダウンロード・コピーフィードバック状態（`copiedUsers`, `copiedMembers`）を集約
- `src/app/page.tsx` をフォーム状態管理と UI レンダリングのみに簡略化
- `docs/architecture.md` のディレクトリ構成に `hooks/` を追記

## Test plan

- [x] `tsc --noEmit` 型エラーなし
- [x] `npm test` 30テストすべてパス

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)