### PR TITLE
fix: T13 マジックナンバー定数化 / T14 onPaste ハンドラ整理

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,20 +77,9 @@ export default function Home() {
                 type="text"
                 value={organizationName}
                 onChange={(e) => setOrganizationName(e.target.value)}
-                onPaste={(e) => {
-                  e.stopPropagation();
-                  try {
-                    const ne = e.nativeEvent as unknown;
-                    if (
-                      typeof ne === "object" &&
-                      ne !== null &&
-                      "stopImmediatePropagation" in ne
-                    )
-                      (
-                        ne as { stopImmediatePropagation: () => void }
-                      ).stopImmediatePropagation();
-                  } catch {}
-                }}
+                // Prevent AccountSpreadsheet's document-level paste handler
+                // from intercepting pastes into this input field.
+                onPaste={(e) => e.nativeEvent.stopPropagation()}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 placeholder="組織名を入力"
               />

--- a/src/lib/sql/generateMembersSql.ts
+++ b/src/lib/sql/generateMembersSql.ts
@@ -9,6 +9,8 @@ import {
 } from "./helpers";
 import type { MemberOptions } from "./types";
 
+const MEMBER_ROLE_PERIOD_STATUS = 2;
+
 export function generateMembersSql(opts: MemberOptions) {
   const { organizationName, pref, city, rows, startDate, endDate, mailDomain } =
     opts;
@@ -43,7 +45,7 @@ export function generateMembersSql(opts: MemberOptions) {
       `(${base}, 'USER', NOW(), NOW()), (${base}, 'GENERAL', NOW(), NOW())`,
     );
     periodVals.push(
-      `(${base}, 'GENERAL', ${q(periodFrom)}, ${q(periodTo)}, 2, NOW(), NOW())`,
+      `(${base}, 'GENERAL', ${q(periodFrom)}, ${q(periodTo)}, ${MEMBER_ROLE_PERIOD_STATUS}, NOW(), NOW())`,
     );
   });
 


### PR DESCRIPTION
## 概要

- **T13 (#28)**: `generateMembersSql.ts` の `status` フィールドのマジックナンバー `2` を `MEMBER_ROLE_PERIOD_STATUS` 定数として定義
- **T14 (#29)**: `page.tsx` の `onPaste` ハンドラの複雑な型キャストを `nativeEvent.stopPropagation()` に整理し、目的をコメントで明記

## 関連 Issue

Closes #28, #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)