### PR TITLE
feat: [T15] bcrypt ハッシュ化を Web Worker に移行し UI ブロッキングを解消

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 | next | 15.5.4 | フレームワーク（App Router） |
 | react | 19.1.0 | UI ライブラリ |
 | react-dom | 19.1.0 | React DOM レンダリング |
-| bcryptjs | ^2.4.3 | パスワードハッシュ（同期処理） |
+| bcryptjs | ^2.4.3 | パスワードハッシュ（Web Worker で非同期実行） |
 
 ### 開発依存
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,8 @@ account-sql-generator/
 │   ├── hooks/
 │   │   ├── useSQLGeneration.ts          # SQL生成・データ加工ロジック
 │   │   └── useClipboardAndDownload.ts   # クリップボードコピー・ファイルダウンロード
+│   ├── workers/
+│   │   └── bcryptWorker.ts              # bcrypt ハッシュ化 Web Worker（UI スレッドをブロックしない）
 │   └── lib/
 │       └── sql/
 │           ├── types.ts             # TypeScript インターフェース定義
@@ -82,6 +84,6 @@ account-sql-generator/
 - `use client` ディレクティブが必要なクライアントコンポーネントは明示的に宣言する
 - `useCallback` / `memo` による最適化を積極的に活用する
 
-### bcryptjs（同期処理）
-- `bcrypt.hashSync()` を使用しており、件数が多い場合に UI スレッドをブロックする可能性がある
-- 数百件以上の大量処理が必要な場合は Web Worker またはサーバーサイド移行を検討すること
+### bcryptjs（Web Worker による非同期処理）
+- `src/workers/bcryptWorker.ts` で bcrypt ハッシュ化を Web Worker に委譲し、UI スレッドのブロッキングを解消している
+- Worker は `new Worker(new URL('../workers/bcryptWorker.ts', import.meta.url))` で生成し、webpack が静的エクスポート時にも正しくバンドルする

--- a/src/hooks/useSQLGeneration.ts
+++ b/src/hooks/useSQLGeneration.ts
@@ -4,13 +4,23 @@ import { useState } from "react";
 import { generateMembersSql } from "@/lib/sql/generateMembersSql";
 import { generateUsersSql } from "@/lib/sql/generateUsersSql";
 import { toUserRows } from "@/lib/sql/helpers";
-import bcrypt from "bcryptjs";
 import type { AccountData } from "@/lib/sql/types";
 
-const hashPassword = (pw: string): string => {
-  const salt = bcrypt.genSaltSync(10);
-  return bcrypt.hashSync(pw, salt);
-};
+const hashPasswords = (passwords: string[]): Promise<string[]> =>
+  new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL("../workers/bcryptWorker.ts", import.meta.url),
+    );
+    worker.onmessage = (e: MessageEvent<string[]>) => {
+      worker.terminate();
+      resolve(e.data);
+    };
+    worker.onerror = (err) => {
+      worker.terminate();
+      reject(err);
+    };
+    worker.postMessage(passwords);
+  });
 
 type UseSQLGenerationProps = {
   organizationName: string;
@@ -48,16 +58,19 @@ export function useSQLGeneration({
 
     setIsGenerating(true);
     setErrorMessage(null);
-    // Allow spinner to render before doing synchronous CPU work.
-    await new Promise((res) => setTimeout(res, 0));
+
 
     try {
-      const mergedRows = [
+      const filteredRows = [
         ...teacherRows.filter((r) => r.userId.trim().length > 0),
         ...studentRows.filter((r) => r.userId.trim().length > 0),
-      ].map((r) => ({
+      ];
+      const hashes = await hashPasswords(
+        filteredRows.map((r) => r.password || "password"),
+      );
+      const mergedRows = filteredRows.map((r, i) => ({
         ...r,
-        password: hashPassword(r.password || "password"),
+        password: hashes[i],
       }));
 
       const usersSql = generateUsersSql({

--- a/src/hooks/useSQLGeneration.ts
+++ b/src/hooks/useSQLGeneration.ts
@@ -6,8 +6,9 @@ import { generateUsersSql } from "@/lib/sql/generateUsersSql";
 import { toUserRows } from "@/lib/sql/helpers";
 import type { AccountData } from "@/lib/sql/types";
 
-const hashPasswords = (passwords: string[]): Promise<string[]> =>
-  new Promise((resolve, reject) => {
+const hashPasswords = (passwords: string[]): Promise<string[]> => {
+  if (passwords.length === 0) return Promise.resolve([]);
+  return new Promise((resolve, reject) => {
     const worker = new Worker(
       new URL("../workers/bcryptWorker.ts", import.meta.url),
     );
@@ -21,6 +22,7 @@ const hashPasswords = (passwords: string[]): Promise<string[]> =>
     };
     worker.postMessage(passwords);
   });
+};
 
 type UseSQLGenerationProps = {
   organizationName: string;

--- a/src/workers/bcryptWorker.ts
+++ b/src/workers/bcryptWorker.ts
@@ -1,0 +1,9 @@
+import bcrypt from "bcryptjs";
+
+self.onmessage = (e: MessageEvent<string[]>) => {
+  const hashes = e.data.map((pw) => {
+    const salt = bcrypt.genSaltSync(10);
+    return bcrypt.hashSync(pw, salt);
+  });
+  self.postMessage(hashes);
+};

--- a/src/workers/bcryptWorker.ts
+++ b/src/workers/bcryptWorker.ts
@@ -1,3 +1,4 @@
+/// <reference lib="webworker" />
 import bcrypt from "bcryptjs";
 
 self.onmessage = (e: MessageEvent<string[]>) => {


### PR DESCRIPTION
## 概要

- `bcrypt.hashSync()`（同期処理）による UI スレッドブロッキングを解消
- `src/workers/bcryptWorker.ts` を新規追加し、bcrypt 処理を Web Worker に移譲
- GitHub Pages（静的エクスポート）環境でも動作（webpack が worker ファイルを別チャンクとしてバンドル）

## 関連 Issue

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)