### PR TITLE
fix: devcontainer イメージタグを Node 24 の正しいタグに修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Node.js & TypeScript",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-24-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:4-24-bookworm",
   "features": {
     "ghcr.io/anthropics/devcontainer-features/claude-code:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}


### PR DESCRIPTION
## 概要

T21 で設定した `typescript-node:1-24-bookworm` は存在しないタグのため、devcontainer が起動できない不具合を修正する。

## 原因

Node 22 は `1-22-bookworm`（イメージ v1.x）が最後だったが、Node 24 対応のイメージはメジャーバージョンが 4.x に上がっており、正しいタグは `4-24-bookworm`。

## 変更内容

- `.devcontainer/devcontainer.json`: `typescript-node:1-24-bookworm` → `4-24-bookworm`

## Test plan

- [ ] devcontainer が正常に起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)