### PR TITLE
fix: @types/bcryptjs を追加して TypeScript ビルドエラーを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
         "@tailwindcss/postcss": "^4",
+        "@types/bcryptjs": "^2",
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1609,6 +1610,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "license": "MIT",
+      "dev": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@vitest/coverage-v8": "^4",
     "vitest": "^4",
     "@tailwindcss/postcss": "^4",
+    "@types/bcryptjs": "^2",
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
## 概要

bcryptjs v2.4.3 は型定義を内包していないため、TypeScript ビルドが失敗していた問題を修正する。

## 原因

bcryptjs v3 は型定義を内包していたが、v2.4.3 にダウングレードしたことで `@types/bcryptjs` が必要になった。

## 変更内容

- `package.json`: `@types/bcryptjs: "^2"` を devDependencies に追加
- `package-lock.json`: `@types/bcryptjs 2.4.6` のエントリを追加

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)