### PR TITLE
ci: Dependabot の bcryptjs 更新を無視する設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: weekly
       day: monday
     target-branch: develop
+    ignore:
+      # bcryptjs は $2a ハッシュ出力維持のため v2.4.3 に固定（T22）
+      - dependency-name: bcryptjs
     groups:
       production-dependencies:
         dependency-type: production


### PR DESCRIPTION
## 概要

bcryptjs は `$2a` ハッシュ出力維持のため v2.4.3 に固定している（T22 #65）。
Dependabot が再アップグレードしないよう `.github/dependabot.yml` に ignore 設定を追加する。

## 変更内容

- `.github/dependabot.yml`: bcryptjs を ignore リストに追加

## 関連

- PR #70（bcryptjs を含む Dependabot PR）は本 PR マージ後に close し、Dependabot に再生成させる

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)