### PR TITLE
ci: Biome CLI 更新時に biome.json を自動マイグレーションする

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.5",
   "private": true,
   "scripts": {
+    "prepare": "biome migrate --write",
     "dev": "next dev",
     "build": "next build",
     "build:static": "cross-env BUILD_MODE=static next build",


### PR DESCRIPTION
## Summary
- Dependabot が `@biomejs/biome` を更新するたびに `biome.json` の `$schema` が追従せず、lint 実行時に schema mismatch の info が出続ける問題への対応
- `package.json` の `prepare` フックで `biome migrate --write` を自動実行し、`npm ci` 時に自動マイグレーションされるようにした

Closes #91

## Test plan
- [ ] CI の lint ステップで schema mismatch の info が出ないことを確認