### PR TITLE
chore: 開発標準（common-rules / workflows）を dev-commons から同期

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -9,7 +9,11 @@ on:
 
 jobs:
   bump:
-    if: github.event.label.name == 'bump:patch' || github.event.label.name == 'bump:minor'
+    # fork PR ではブランチが base 側に無く GITHUB_TOKEN も read-only のため push に失敗する。
+    # 同一リポジトリの PR に限定し、fork PR は（失敗させず）スキップする。
+    if: >
+      (github.event.label.name == 'bump:patch' || github.event.label.name == 'bump:minor')
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,7 +31,8 @@ jobs:
         id: bump
         run: |
           TYPE=${{ github.event.label.name == 'bump:minor' && 'minor' || 'patch' }}
-          npm version $TYPE --no-git-tag-version
+          # --ignore-scripts: PR 側 package.json の preversion/version/postversion を実行させない（サプライチェーン対策）
+          npm version $TYPE --no-git-tag-version --ignore-scripts
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}
+          # デフォルトブランチ（develop 等）ではなく、実行契機の master コミットにタグを貼る
+          target_commitish: ${{ github.sha }}
           name: v${{ steps.version.outputs.version }}
           draft: false
           prerelease: false


### PR DESCRIPTION
dev-commons の `sync/` 配下を同期する自動 PR（profile: pages-app）。更新ファイル: .github/workflows/bump-version.yml .github/workflows/release.yml

配布ファイルの正は dev-commons 側。これらのファイルはリポジトリ内で直接編集しないこと（次回同期で上書きされる）。