### PR TITLE
chore: .gitignore に .claude/api-rules.md・project.md の除外例外を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,6 @@ next-env.d.ts
 # local tools
 .claude/*
 !.claude/common-rules.md
+!.claude/api-rules.md
+!.claude/project.md
 .playwright-mcp/


### PR DESCRIPTION
3層構造の移行で新規配布される `.claude/api-rules.md`、およびリポ所有の `.claude/project.md` を追跡できるよう、`.claude/*` 除外の例外を追加する。これが無いと `sync-standards` が配布時に gitignore で弾かれて失敗する（本リポは実際に失敗を検知済み）。

**この PR を先にマージ**してから sync 配布 → 3層移行、の順で進める。

Refs: ot-nemoto/dev-commons#36